### PR TITLE
Addressed #26

### DIFF
--- a/FeBuddyLibrary/DataAccess/GetAptData.cs
+++ b/FeBuddyLibrary/DataAccess/GetAptData.cs
@@ -414,6 +414,7 @@ namespace FeBuddyLibrary.DataAccess
 
                 foreach (RunwayModel runwayModel in aptModel.Runways)
                 {
+                    doNotUseThisRwy = false;
                     List<string> rwyProperties = new List<string>()
                     {
                         runwayModel.RwyGroup,


### PR DESCRIPTION
When filtering out bad runways, if the first runway is bad we dont use it and never set our variable back to false.
This has been fixed and a MAXIMUM of 53 airports have been effected by this error.