### PR TITLE
Add build script for creating squirrel packages 

### DIFF
--- a/FeBuddyWinFormUI/FeBuddyWinFormUI.csproj
+++ b/FeBuddyWinFormUI/FeBuddyWinFormUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -9,6 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>FE_BUDDY_icon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -File ./build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,41 @@
+# Stop the script if an error occurs
+$ErrorActionPreference = "Stop"
+$pubdir = "$PSScriptRoot\publish"
+$releasedir = "$PSScriptRoot\releases"
+
+# Ensure a clean state by removing build/package folders
+$Folders = @($pubdir, $releasedir, "$PSScriptRoot\FeBuddyWinFormUI\obj", "$PSScriptRoot\FeBuddyWinFormUI\bin")
+foreach ($Folder in $Folders) {
+    if (Test-Path $Folder) {
+        Remove-Item -path "$Folder" -Recurse -Force
+    }
+}
+
+# Publish projects and remove unnecessary WPF files
+dotnet publish -v minimal -c Release -r win-x86 --self-contained "$PSScriptRoot\FeBuddyWinFormUI\FeBuddyWinFormUI.csproj" -o "$pubdir"
+Remove-Item "$pubdir\WindowsBase.dll"
+Remove-Item "$pubdir\DirectWriteForwarder.dll"
+Remove-Item "$pubdir\WindowsFormsIntegration.dll"
+Remove-Item "$pubdir\System.Xaml.dll"
+Remove-Item "$pubdir\System.Windows.dll"
+Remove-Item "$pubdir\System.Windows.Controls.Ribbon.dll"
+Remove-Item "$pubdir\System.Windows.Extensions.dll"
+Remove-Item "$pubdir\System.Windows.Presentation.dll"
+Remove-Item "$pubdir\System.Windows.Input.Manipulations.dll"
+Get-ChildItem -Path "$pubdir" -Filter "*cor3*" | Remove-Item -Force -Recurse
+Get-ChildItem -Path "$pubdir" -Filter "*Presentation*" | Remove-Item -Force -Recurse
+Get-ChildItem -Path "$pubdir" -Filter "*UIAutomation*" | Remove-Item -Force -Recurse
+
+# Get current product version from main dll FileVersion
+$verObj = Get-ChildItem -Path "$pubdir\FE-BUDDY.dll" -Recurse | Select-Object -ExpandProperty VersionInfo
+$ver = $verObj.ProductVersion
+Write-Output "Building version $ver"
+
+# Squirrel release
+Set-Alias Squirrel ($env:USERPROFILE + "\.nuget\packages\clowd.squirrel\2.7.98-pre\tools\Squirrel.exe")
+New-Item -Path "$PSScriptRoot" -Name "releases" -ItemType "directory"
+Squirrel github-down --repoUrl "https://github.com/Nikolai558/FE-BUDDY" -r "$releasedir"
+Squirrel pack -u "FE-BUDDY" -v "$ver" -p "$pubdir" -r "$releasedir"
+
+Write-Output ""
+Write-Output "Build Complete"


### PR DESCRIPTION
This build script will do the following: 
- publish the application in release mode, 
- delete WPF binaries from publish that are not needed by FE-BUDDY
- download latest/previous release from GitHub
- create a squirrel package with the current version (uses version specified in .csproj), and create a delta release with the previous release

I did not update your build instructions in this commit, but the new steps to create a new version are just to: 
- Update version in `FeBuddyWinFormUI.csproj`
- Run `build.cmd`
- Upload `RELEASES` file, `Setup.exe`, as well as the `-full` and `-delta` package to GitHub and create a new release

There is also no need to download Squirrel manually to create releases, as the necessary tools are already included with the nuget package in your appdata folder. 