### PR TITLE
Illegal Lon Fix

### DIFF
--- a/FeBuddyLibrary/Helpers/LatLonHelpers.cs
+++ b/FeBuddyLibrary/Helpers/LatLonHelpers.cs
@@ -206,12 +206,13 @@ namespace FeBuddyLibrary.Helpers
 
         public static double CorrectIlleagleLon(double value)
         {
-            double tempvalue = Math.Abs(value);
-            if (tempvalue > 180)
+            if (value > 180)
             {
-                return (180 - (tempvalue % 180));
+                return ((value % 180) - 180);
+            } else if (value <= -180)
+            {
+                return (180 - (value % 180));
             }
-
             return value;
         }
 


### PR DESCRIPTION
Altered the Illegal Lon check to allow bi-directional flow (E-> and W->E), which was being prevented by the use of the ABS function. Instead, the % must be positioned properly depending on the E or W direction: 180-(mod) vs (mod)-180.