### PR TITLE
Split Airways to appropriate Group

### DIFF
--- a/FeBuddyLibrary/DataAccess/GetAtsAwyData.cs
+++ b/FeBuddyLibrary/DataAccess/GetAtsAwyData.cs
@@ -179,14 +179,15 @@ namespace FeBuddyLibrary.DataAccess
         /// </summary>
         private void WriteAwySctData()
         {
+            // Warning: AwyData must be preformed before AtsAwyData, Refactoring of this code is needed! 
             Logger.LogMessage("INFO", "STARTED AWY SCT WRITER");
 
             // Set our File Path
-            string filePath = $"{GlobalConfig.outputDirectory}\\VRC\\[LOW AIRWAY].sct2";
+            string filePath = $"{GlobalConfig.outputDirectory}\\VRC\\[HIGH AIRWAY].sct2";
 
             StringBuilder sb = new StringBuilder();
 
-            sb.AppendLine("[LOW AIRWAY]");
+            //sb.AppendLine("[HIGH AIRWAY]");
 
             foreach (AtsAirwayModel airway in allAtsAwy)
             {

--- a/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
+++ b/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
@@ -358,6 +358,11 @@ namespace FeBuddyWinFormUI
             SetControlPropertyThreadSafe(processingDataLabel, "Text", "Processing Airways");
             FileHelpers.CreateAwyGeomapHeadersAndEnding(true);
 
+
+            // ------------------------------------------------------------------------------------------------------
+            // DO NOT CHANGE THE ORDER OF THESE TWO ITEMS, REFACTORING THIS IS NEEDED!!!!!
+            // Warning: AwyData must be preformed before AtsAwyData, Refactoring of this code is needed! 
+
             GetAwyData ParseAWY = new GetAwyData();
             ParseAWY.AWYQuarterbackFunc(GlobalConfig.airacEffectiveDate);
 
@@ -365,6 +370,9 @@ namespace FeBuddyWinFormUI
             GetAtsAwyData ParseAts = new GetAtsAwyData();
             ParseAts.AWYQuarterbackFunc(GlobalConfig.airacEffectiveDate);
             FileHelpers.CreateAwyGeomapHeadersAndEnding(false);
+
+            // ------------------------------------------------------------------------------------------------------
+
 
             SetControlPropertyThreadSafe(processingDataLabel, "Text", "Processing NDBs");
             GetNavData ParseNDBs = new GetNavData();


### PR DESCRIPTION
Filtered out all non "V, T, Q, J" airways from the AwyData. 
All AtsAwyData is placed in side the High Airway file.

Kept all data for the find fix alias command for EVERY Airway.

Dev Notes: 
Warning: AwyData must be preformed before AtsAwyData, Refactoring of this code is needed!