### PR TITLE
Modernize AIRAC lookup and HTTP stack

### DIFF
--- a/FeBuddyLibrary/Helpers/AiracHelper.cs
+++ b/FeBuddyLibrary/Helpers/AiracHelper.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace FeBuddyLibrary.Helpers
+{
+    /// <summary>
+    /// AIRAC cycle math + authoritative lookup via FAA APRA.
+    ///
+    /// Cycle dates are deterministic (28-day interval from ICAO epoch), so
+    /// offline math is the primary source. APRA (external-api.faa.gov) is
+    /// consulted as the authoritative cross-check and to confirm FAA has
+    /// actually published a given product edition.
+    /// </summary>
+    public static class AiracHelper
+    {
+        // ICAO AIRAC epoch: cycle 2001 effective 2020-01-02.
+        private static readonly DateTime Epoch =
+            new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        private const int CycleDays = 28;
+
+        private static readonly XNamespace ApraNs = "http://arpa.ait.faa.gov/arpa_response";
+
+        private static HttpClient Http => SharedHttp.Client;
+
+        public readonly struct AiracCycle
+        {
+            public AiracCycle(DateTime effective)
+            {
+                Effective = DateTime.SpecifyKind(effective.Date, DateTimeKind.Utc);
+            }
+
+            public DateTime Effective { get; }
+
+            /// <summary>ICAO 4-digit cycle identifier, e.g. "2604" for the 4th cycle of 2026.</summary>
+            public string Id
+            {
+                get
+                {
+                    var jan1 = new DateTime(Effective.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                    int firstCycleOfYear = (int)Math.Ceiling((jan1 - Epoch).TotalDays / CycleDays);
+                    int thisCycle = (int)((Effective - Epoch).TotalDays / CycleDays);
+                    int ordinal = thisCycle - firstCycleOfYear + 1;
+                    return $"{Effective.Year % 100:D2}{ordinal:D2}";
+                }
+            }
+
+            /// <summary>FAA d-tpp directory name — the 4-digit cycle id.</summary>
+            public string FaaDirectory => Id;
+
+            public AiracCycle Next => new AiracCycle(Effective.AddDays(CycleDays));
+            public AiracCycle Previous => new AiracCycle(Effective.AddDays(-CycleDays));
+
+            public override string ToString() => $"{Id} ({Effective:yyyy-MM-dd})";
+        }
+
+        public static AiracCycle Current(DateTime? utcNow = null)
+        {
+            var now = (utcNow ?? DateTime.UtcNow).ToUniversalTime();
+            int cycles = (int)((now - Epoch).TotalDays / CycleDays);
+            return new AiracCycle(Epoch.AddDays(cycles * CycleDays));
+        }
+
+        public static AiracCycle Next(DateTime? utcNow = null) => Current(utcNow).Next;
+
+        // ---------------------------------------------------------------
+        // FAA APRA client
+        // https://external-api.faa.gov/apra/{product}/info?edition={current|next}
+        // ---------------------------------------------------------------
+
+        public enum ApraEdition { Current, Next }
+
+        /// <summary>
+        /// A single product edition record returned by APRA.
+        /// </summary>
+        public readonly struct ApraEditionInfo
+        {
+            public ApraEditionInfo(string editionName, DateTime editionDate, int editionNumber,
+                                   string geoname, string format)
+            {
+                EditionName = editionName;
+                EditionDate = editionDate;
+                EditionNumber = editionNumber;
+                Geoname = geoname;
+                Format = format;
+            }
+
+            public string EditionName { get; }
+            public DateTime EditionDate { get; }
+            public int EditionNumber { get; }
+            public string Geoname { get; }
+            public string Format { get; }
+
+            /// <summary>4-digit AIRAC cycle id built from the edition date + number.</summary>
+            public string CycleId =>
+                $"{EditionDate.Year % 100:D2}{EditionNumber:D2}";
+
+            public AiracCycle AsCycle() => new AiracCycle(EditionDate);
+        }
+
+        /// <summary>
+        /// Queries APRA for an edition of a product (e.g. "dtpp", "cifp", "supp").
+        /// Returns null if the API responded with a non-200 status attribute or the
+        /// network call failed — callers should fall back to <see cref="Current"/>.
+        /// </summary>
+        public static async Task<ApraEditionInfo?> GetApraEditionAsync(
+            string product, ApraEdition edition, CancellationToken ct = default)
+        {
+            var url = $"https://external-api.faa.gov/apra/{product}/info" +
+                      $"?edition={(edition == ApraEdition.Current ? "current" : "next")}";
+            try
+            {
+                var xml = await Http.GetStringAsync(url, ct).ConfigureAwait(false);
+                var doc = XDocument.Parse(xml);
+                var status = doc.Root?.Element(ApraNs + "status");
+                if (status?.Attribute("code")?.Value != "200") return null;
+
+                var ed = doc.Root?.Element(ApraNs + "edition");
+                if (ed is null) return null;
+
+                var date = DateTime.ParseExact(
+                    ed.Element(ApraNs + "editionDate")!.Value,
+                    "MM/dd/yyyy", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+
+                return new ApraEditionInfo(
+                    editionName:   ed.Attribute("editionName")?.Value ?? "",
+                    editionDate:   date,
+                    editionNumber: int.Parse(ed.Element(ApraNs + "editionNumber")!.Value,
+                                             CultureInfo.InvariantCulture),
+                    geoname:       ed.Attribute("geoname")?.Value ?? "",
+                    format:        ed.Attribute("format")?.Value ?? "");
+            }
+            catch (HttpRequestException) { return null; }
+            catch (TaskCanceledException) { return null; }
+            catch (System.Xml.XmlException) { return null; }
+        }
+
+        /// <summary>
+        /// Authoritative current cycle from APRA's d-tpp feed, falling back to
+        /// deterministic math if APRA is unreachable.
+        /// </summary>
+        public static async Task<AiracCycle> ResolveCurrentAsync(CancellationToken ct = default)
+        {
+            var apra = await GetApraEditionAsync("dtpp", ApraEdition.Current, ct).ConfigureAwait(false);
+            return apra?.AsCycle() ?? Current();
+        }
+
+        public static async Task<AiracCycle> ResolveNextAsync(CancellationToken ct = default)
+        {
+            var apra = await GetApraEditionAsync("dtpp", ApraEdition.Next, ct).ConfigureAwait(false);
+            return apra?.AsCycle() ?? Next();
+        }
+
+        /// <summary>
+        /// Returns true only when the d-tpp Metafile for this cycle is
+        /// actually hosted on aeronav.faa.gov. APRA announces the next
+        /// edition ahead of publication, so checking APRA alone falsely
+        /// greenlights downloads before files exist.
+        /// </summary>
+        public static async Task<bool> IsPublishedAsync(AiracCycle cycle, CancellationToken ct = default)
+        {
+            var url = $"https://aeronav.faa.gov/d-tpp/{cycle.FaaDirectory}/xml_data/d-tpp_Metafile.xml";
+            try
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Head, url);
+                using var resp = await Http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+                return resp.StatusCode == HttpStatusCode.OK;
+            }
+            catch (HttpRequestException) { return false; }
+            catch (TaskCanceledException) { return false; }
+        }
+    }
+}

--- a/FeBuddyLibrary/Helpers/DownloadHelpers.cs
+++ b/FeBuddyLibrary/Helpers/DownloadHelpers.cs
@@ -1,12 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 
 namespace FeBuddyLibrary.Helpers
 {
     public class DownloadHelpers
     {
+        private static void DownloadFile(string url, string destPath)
+        {
+            using var response = SharedHttp.Client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead)
+                                                  .GetAwaiter().GetResult();
+            response.EnsureSuccessStatusCode();
+            using var src = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+            using var dst = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            src.CopyTo(dst);
+        }
+
         public static void DownloadAllFiles(string effectiveDate, string airacCycle, bool getMetaFile = true)
         {
             Logger.LogMessage("DEBUG", "DOWNLOADING ALL FILES REQUIRED");
@@ -53,10 +63,7 @@ namespace FeBuddyLibrary.Helpers
                 };
             }
 
-            // Web Client used to connect to the FAA website.
-            using (var client = new WebClient())
-            {
-                foreach (string fileName in allURLs.Keys)
+            foreach (string fileName in allURLs.Keys)
                 {
                     if (File.Exists($"{GlobalConfig.tempPath}\\{fileName}") && GlobalConfig.DEVMODE)
                     {
@@ -87,12 +94,12 @@ namespace FeBuddyLibrary.Helpers
                             }
                             else
                             {
-                                client.DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
+                                DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
                             }
                         }
                         else
                         {
-                            client.DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
+                            DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
                         }
                         Logger.LogMessage("INFO", $"DOWNLOAD SUCCESSFUL: {fileName}");
 
@@ -108,7 +115,6 @@ namespace FeBuddyLibrary.Helpers
                     }
                     GlobalConfig.DownloadedFilePaths.Add($"{GlobalConfig.tempPath}\\{fileName}");
                 }
-            }
         }
     }
 }

--- a/FeBuddyLibrary/Helpers/SharedHttp.cs
+++ b/FeBuddyLibrary/Helpers/SharedHttp.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net.Http;
+
+namespace FeBuddyLibrary.Helpers
+{
+    /// <summary>
+    /// Single process-wide HttpClient. Reusing one client avoids socket
+    /// exhaustion from the classic "new HttpClient() per call" anti-pattern
+    /// and picks up the OS TLS 1.2/1.3 defaults on .NET 6.
+    /// </summary>
+    public static class SharedHttp
+    {
+        public static readonly HttpClient Client = new HttpClient(new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+        })
+        {
+            Timeout = TimeSpan.FromMinutes(2),
+        };
+    }
+}

--- a/FeBuddyLibrary/Helpers/WebHelpers.cs
+++ b/FeBuddyLibrary/Helpers/WebHelpers.cs
@@ -1,13 +1,10 @@
-﻿using System.IO;
+using System.IO;
 using System.IO.Compression;
-using System.Net;
-using FeBuddyLibrary.Models.MetaFileModels;
 
 namespace FeBuddyLibrary.Helpers
 {
     public class WebHelpers
     {
-
         public static void DecompressGZipFile(string gzipFilePath, string destFilePath)
         {
             using (FileStream originalFileStream = new FileStream(gzipFilePath, FileMode.Open, FileAccess.Read))
@@ -20,87 +17,6 @@ namespace FeBuddyLibrary.Helpers
                     }
                 }
             }
-        }
-
-        public static bool GetMetaUrlResponse()
-        {
-            Logger.LogMessage("DEBUG", "CHECKING IF NEXT AIRAC HAS THE META FILE OR NOT");
-
-            string nextUrl = $"https://aeronav.faa.gov/d-tpp/{AiracDateCycleModel.AllCycleDates[GlobalConfig.nextAiracDate]}/xml_data/d-tpp_Metafile.xml";
-            //string testUrl = $"https://aeronav.faa.gov/d-tpp/2201/xml_data/d-tpp_Metafile.xml";
-
-            HttpStatusCode result;
-
-            try
-            {
-                var request = HttpWebRequest.Create(nextUrl);
-                request.Method = "HEAD";
-                if (request.GetResponse() is HttpWebResponse response)
-                {
-                    if (response != null)
-                    {
-                        result = response.StatusCode;
-                    }
-
-                    response.Close();
-                }
-
-                Logger.LogMessage("DEBUG", "NEXT AIRAC IS AVAILABLE");
-                return true;
-            }
-            catch (WebException)
-            {
-                Logger.LogMessage("DEBUG", "NEXT AIRAC NOT AVAILABLE");
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get the Airac Effective Dates and Set our Global Variables to it.
-        /// </summary>
-        public static void GetAiracDateFromFAA()
-        {
-            Logger.LogMessage("DEBUG", "SEARCHING FAA WEBSITE FOR AIRAC DATES");
-
-            // FAA URL that contains the effective dates for both Current and Next AIRAC Cycles.
-            string url = "https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/";
-
-            string response;
-
-            BatchFileHelpers.CreateCurlBatchFile("getAiraccEff.bat", "https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/", $"{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML");
-
-            BatchFileHelpers.ExecuteCurlBatchFile("getAiraccEff.bat");
-
-            if (File.Exists($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML") && File.ReadAllText($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML").Length > 10)
-            {
-                Logger.LogMessage("DEBUG", "GOT RESPONSE FROM FAA WEBSITE");
-                response = File.ReadAllText($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML");
-
-                Logger.LogMessage("DEBUG", "USER HAS CURL");
-                GlobalConfig.hasCurl = true;
-            }
-            else
-            {
-                Logger.LogMessage("WARNING", "USER DOES NOT HAVE CURL OR IT FAILED");
-                GlobalConfig.hasCurl = false;
-                using (var client = new System.Net.WebClient())
-                {
-                    client.Proxy = null;
-
-                    //client.Proxy = GlobalProxySelection.GetEmptyWebProxy();
-                    response = client.DownloadString(url);
-                    Logger.LogMessage("DEBUG", "GOT AIRAC DATE USING WEBCLIENT");
-                }
-            }
-
-            response.Trim();
-
-            // Find the two strings that contain the effective date and set our Global Variables.
-            GlobalConfig.nextAiracDate = response.Substring(response.IndexOf("./../NASR_Subscription") + 23, 10);
-            GlobalConfig.currentAiracDate = response.Substring(response.LastIndexOf("./../NASR_Subscription") + 23, 10);
-            Logger.LogMessage("INFO", $"CURRENT AIRAC DATE: {GlobalConfig.currentAiracDate} / NEXT AIRAC DATE: {GlobalConfig.nextAiracDate}");
-
         }
     }
 }

--- a/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
+++ b/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
@@ -466,9 +466,13 @@ namespace FeBuddyWinFormUI
 
             if (GlobalConfig.nextAiracDate == null)
             {
-                WebHelpers.GetAiracDateFromFAA();
+                var current = AiracHelper.ResolveCurrentAsync().GetAwaiter().GetResult();
+                var next    = AiracHelper.ResolveNextAsync().GetAwaiter().GetResult();
+                GlobalConfig.currentAiracDate = current.Effective.ToString("yyyy-MM-dd");
+                GlobalConfig.nextAiracDate    = next.Effective.ToString("yyyy-MM-dd");
+                Logger.LogMessage("INFO", $"CURRENT AIRAC DATE: {GlobalConfig.currentAiracDate} / NEXT AIRAC DATE: {GlobalConfig.nextAiracDate}");
             }
-            nextAiracAvailable = WebHelpers.GetMetaUrlResponse();
+            nextAiracAvailable = AiracHelper.IsPublishedAsync(AiracHelper.Next()).GetAwaiter().GetResult();
         }
 
         private void Worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/FeBuddyWinFormUI/WinForms/UpdateForm.cs
+++ b/FeBuddyWinFormUI/WinForms/UpdateForm.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.IO;
-using System.Net;
 using System.Windows.Forms;
 using FeBuddyLibrary.Helpers;
 
@@ -90,13 +88,7 @@ namespace FeBuddyWinFormUI
             string content = "";
 
             string url = "https://raw.githubusercontent.com/Nikolai558/FE-BUDDY/releases/ChangeLog.md";
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-
-            using (var reader = new StreamReader(response.GetResponseStream()))
-            {
-                content = reader.ReadToEnd();
-            }
+            content = SharedHttp.Client.GetStringAsync(url).GetAwaiter().GetResult();
 
             foreach (string line in content.Split('\n'))
             {


### PR DESCRIPTION
## Summary

Replaces the FAA HTML-scrape path for AIRAC dates with a deterministic cycle calculator backed by FAA's APRA API, and migrates the HTTP clients off the deprecated `WebClient` / `HttpWebRequest` types.

## Motivation

The previous AIRAC date flow in `WebHelpers.GetAiracDateFromFAA`:

1. Wrote a `.bat` file invoking `curl.exe`.
2. Parsed the resulting HTML by substring index against a hard-coded `"./../NASR_Subscription"` + 23 byte offset.
3. Fell back to `WebClient` on failure.

Fragility in that path, any one of which produced silent misreads or hangs:

- Missing `curl.exe` on older Windows.
- `WebClient` / `HttpWebRequest` defaulting to TLS 1.0/1.1 on older .NET runtimes.
- Corporate proxies rejecting the `Proxy = null` bypass.
- AV software quarantining auto-generated `.bat` files.
- FAA HTML layout changes breaking the substring offset.
- No status-code check on the "success" path.

All of these are eliminated by the new helper.

## Changes

### `FeBuddyLibrary/Helpers/AiracHelper.cs` (new)

AIRAC cycles are fixed on a 28-day cadence from the ICAO epoch (cycle 2001 effective 2020-01-02), so the current and next cycle dates can be computed locally without any network call. APRA (`external-api.faa.gov`) is used as an authoritative cross-check when reachable and as the "is next cycle announced" signal; if it fails the code falls back to the deterministic math.

- `Current` / `Next`: pure math, no I/O.
- `ResolveCurrentAsync` / `ResolveNextAsync`: APRA with math fallback.
- `IsPublishedAsync`: HEAD-probes the d-tpp Metafile on `aeronav.faa.gov` so the UI only enables the "next AIRAC" option when files are physically hosted, not merely announced.
- Handles the 14-cycle-year case (e.g. 2020 ran 2001..2014) correctly.

### `FeBuddyLibrary/Helpers/SharedHttp.cs` (new)

Single process-wide `HttpClient`. Reusing one client avoids the classic socket-exhaustion anti-pattern and picks up the OS TLS 1.2/1.3 defaults on .NET 6.

### `FeBuddyWinFormUI/WinForms/AiracDataForm.cs`

`Worker_DoWork` now:

- Calls `AiracHelper.ResolveCurrentAsync` / `ResolveNextAsync` to populate `GlobalConfig.currentAiracDate` and `nextAiracDate` (same `yyyy-MM-dd` format the rest of the app already uses).
- Calls `AiracHelper.IsPublishedAsync(AiracHelper.Next())` to test next-cycle availability.

### `FeBuddyLibrary/Helpers/WebHelpers.cs`

- Delete `GetAiracDateFromFAA` (HTML-scrape + curl batch file + index arithmetic on `response.Substring`). Replacement is `AiracHelper`.
- Delete `GetMetaUrlResponse` (`HttpWebRequest` HEAD probe). Equivalent is `AiracHelper.IsPublishedAsync`.
- Retain `DecompressGZipFile`.

### `FeBuddyLibrary/Helpers/DownloadHelpers.cs`

- Migrate from `WebClient.DownloadFile` to `SharedHttp` + `HttpClient` stream copy. Same synchronous semantics for callers; the UI flow is unchanged.
- Note: `GlobalConfig.hasCurl` is no longer assigned anywhere (the only setters lived inside the deleted `GetAiracDateFromFAA`), so the `if (GlobalConfig.hasCurl)` branches in `DownloadHelpers` are now unreachable. Behavior is unchanged because those branches targeted identical URLs to the non-curl branch; a follow-up PR can prune them.

### `FeBuddyWinFormUI/WinForms/UpdateForm.cs`

- `ReadChangeLog` migrated from `HttpWebRequest` + `StreamReader` to `SharedHttp.Client.GetStringAsync`. Single call, no manual buffering.

## Test plan

- [x] AIRAC ID math verified against the ICAO-published schedule from 2020 through 2030 (31 known cycle dates), including the 2020 14-cycle year and the 2020 -> 2021 boundary at 2014 -> 2101.
- [x] Boundary checks: `23:59:59` day-before vs `00:00:00` day-of effective.
- [x] Live APRA probes of `dtpp/current`, `dtpp/next`, `cifp/current`, `cifp/next` produce 200 responses whose `editionDate` + `editionNumber` combine to the same 4-digit cycle id as the offline math.
- [x] Live HEAD probes against `aeronav.faa.gov/d-tpp/{cycle}/xml_data/d-tpp_Metafile.xml` confirm the `IsPublishedAsync` semantic: 200 for the current cycle, 404 for not-yet-hosted future cycles.
- [x] End-to-end: ran the app on Windows, selected current AIRAC, all 11 downloads succeeded and the full parse pipeline completed through publication parsing.

## Not included in this PR

- Retiring `Models/MetaFileModels/AiracDateCycleModel.cs` (the ~3k-line hard-coded cycle dictionary). Its 9 remaining consumers can be routed through `AiracHelper.AiracCycle.Id` as a follow-up.
- Pruning the now-unreachable curl-batch branches in `DownloadHelpers`.
- Migrating the remaining `BatchFileHelpers` callers (NWS, telephony, d-tpp meta) to `HttpClient`.