### PR TITLE
Modernize HTTP layer; replace HTML-scraped AIRAC lookup with FAA APRA

### DIFF
--- a/FeBuddyLibrary/DataAccess/AircraftData.cs
+++ b/FeBuddyLibrary/DataAccess/AircraftData.cs
@@ -24,8 +24,6 @@ namespace FeBuddyLibrary.DataAccess
 
         private async Task<AircraftDataRootObject> GetACDataAsync()
         {
-            HttpClient client = new HttpClient();
-
             var url = "https://www4.icao.int/doc8643/External/AircraftTypes";
             var values = new Dictionary<string, string>
             {
@@ -37,7 +35,7 @@ namespace FeBuddyLibrary.DataAccess
             };
 
             var content = new FormUrlEncodedContent(values);
-            var response = await client.PostAsync(url, content);
+            var response = await SharedHttp.Client.PostAsync(url, content);
 
             string responseStringJson = await response.Content.ReadAsStringAsync();
 

--- a/FeBuddyLibrary/GlobalConfig.cs
+++ b/FeBuddyLibrary/GlobalConfig.cs
@@ -50,7 +50,5 @@ namespace FeBuddyLibrary
             "ZHU","ZID","ZJX","ZKC","ZLA","ZLC","ZMA","ZME","ZMP","ZNY","ZOA","ZOB","ZSE","ZSU",
             "ZTL","ZUA","ZUL","ZVR","ZWG","ZYZ"
         };
-
-        public static bool hasCurl;
     }
 }

--- a/FeBuddyLibrary/Helpers/AiracHelper.cs
+++ b/FeBuddyLibrary/Helpers/AiracHelper.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace FeBuddyLibrary.Helpers
+{
+    /// <summary>
+    /// AIRAC cycle math + authoritative lookup via FAA APRA.
+    ///
+    /// Cycle dates are deterministic (28-day interval from ICAO epoch), so
+    /// offline math is the primary source. APRA (external-api.faa.gov) is
+    /// consulted as the authoritative cross-check and to confirm FAA has
+    /// actually published a given product edition.
+    /// </summary>
+    public static class AiracHelper
+    {
+        // ICAO AIRAC epoch: cycle 2001 effective 2020-01-02.
+        private static readonly DateTime Epoch =
+            new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+
+        private const int CycleDays = 28;
+
+        // FAA's actual namespace literal is "arpa" — not a typo of "apra".
+        // The URL path uses "apra" (the product name); the response namespace
+        // uses "arpa". Don't "fix" this.
+        private static readonly XNamespace ApraNs = "http://arpa.ait.faa.gov/arpa_response";
+
+        private static HttpClient Http => SharedHttp.Client;
+
+        public readonly struct AiracCycle
+        {
+            public AiracCycle(DateTime effective)
+            {
+                Effective = DateTime.SpecifyKind(effective.Date, DateTimeKind.Utc);
+            }
+
+            public DateTime Effective { get; }
+
+            /// <summary>ICAO 4-digit cycle identifier, e.g. "2604" for the 4th cycle of 2026.</summary>
+            public string Id
+            {
+                get
+                {
+                    var jan1 = new DateTime(Effective.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                    int firstCycleOfYear = (int)Math.Ceiling((jan1 - Epoch).TotalDays / CycleDays);
+                    int thisCycle = (int)((Effective - Epoch).TotalDays / CycleDays);
+                    int ordinal = thisCycle - firstCycleOfYear + 1;
+                    return $"{Effective.Year % 100:D2}{ordinal:D2}";
+                }
+            }
+
+            /// <summary>FAA d-tpp directory name — the 4-digit cycle id.</summary>
+            public string FaaDirectory => Id;
+
+            public AiracCycle Next => new AiracCycle(Effective.AddDays(CycleDays));
+            public AiracCycle Previous => new AiracCycle(Effective.AddDays(-CycleDays));
+
+            public override string ToString() => $"{Id} ({Effective:yyyy-MM-dd})";
+        }
+
+        public static AiracCycle Current(DateTime? utcNow = null)
+        {
+            var now = (utcNow ?? DateTime.UtcNow).ToUniversalTime();
+            int cycles = (int)((now - Epoch).TotalDays / CycleDays);
+            return new AiracCycle(Epoch.AddDays(cycles * CycleDays));
+        }
+
+        public static AiracCycle Next(DateTime? utcNow = null) => Current(utcNow).Next;
+
+        // ---------------------------------------------------------------
+        // FAA APRA client
+        // https://external-api.faa.gov/apra/{product}/info?edition={current|next}
+        // ---------------------------------------------------------------
+
+        public enum ApraEdition { Current, Next }
+
+        /// <summary>
+        /// A single product edition record returned by APRA.
+        /// </summary>
+        public readonly struct ApraEditionInfo
+        {
+            public ApraEditionInfo(string editionName, DateTime editionDate, int editionNumber,
+                                   string geoname, string format)
+            {
+                EditionName = editionName;
+                EditionDate = editionDate;
+                EditionNumber = editionNumber;
+                Geoname = geoname;
+                Format = format;
+            }
+
+            public string EditionName { get; }
+            public DateTime EditionDate { get; }
+            public int EditionNumber { get; }
+            public string Geoname { get; }
+            public string Format { get; }
+
+            /// <summary>4-digit AIRAC cycle id built from the edition date + number.</summary>
+            public string CycleId =>
+                $"{EditionDate.Year % 100:D2}{EditionNumber:D2}";
+
+            public AiracCycle AsCycle() => new AiracCycle(EditionDate);
+        }
+
+        /// <summary>
+        /// Queries APRA for an edition of a product (e.g. "dtpp", "cifp", "supp").
+        /// Returns null if the API responded with a non-200 status attribute or the
+        /// network call failed — callers should fall back to <see cref="Current"/>.
+        /// </summary>
+        public static async Task<ApraEditionInfo?> GetApraEditionAsync(
+            string product, ApraEdition edition, CancellationToken ct = default)
+        {
+            var url = $"https://external-api.faa.gov/apra/{product}/info" +
+                      $"?edition={(edition == ApraEdition.Current ? "current" : "next")}";
+            try
+            {
+                var xml = await Http.GetStringAsync(url, ct).ConfigureAwait(false);
+                var doc = XDocument.Parse(xml);
+                var status = doc.Root?.Element(ApraNs + "status");
+                if (status?.Attribute("code")?.Value != "200") return null;
+
+                var ed = doc.Root?.Element(ApraNs + "edition");
+                if (ed is null) return null;
+
+                var date = DateTime.ParseExact(
+                    ed.Element(ApraNs + "editionDate")!.Value,
+                    "MM/dd/yyyy", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+
+                return new ApraEditionInfo(
+                    editionName:   ed.Attribute("editionName")?.Value ?? "",
+                    editionDate:   date,
+                    editionNumber: int.Parse(ed.Element(ApraNs + "editionNumber")!.Value,
+                                             CultureInfo.InvariantCulture),
+                    geoname:       ed.Attribute("geoname")?.Value ?? "",
+                    format:        ed.Attribute("format")?.Value ?? "");
+            }
+            catch (HttpRequestException ex)
+            {
+                Logger.LogMessage("WARNING", $"APRA {product}/{edition} fetch failed: {ex.Message}");
+                return null;
+            }
+            catch (TaskCanceledException)
+            {
+                return null;
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                Logger.LogMessage("WARNING", $"APRA {product}/{edition} returned malformed XML: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Authoritative current cycle from APRA's d-tpp feed, falling back to
+        /// deterministic math if APRA is unreachable.
+        /// </summary>
+        public static async Task<AiracCycle> ResolveCurrentAsync(CancellationToken ct = default)
+        {
+            var apra = await GetApraEditionAsync("dtpp", ApraEdition.Current, ct).ConfigureAwait(false);
+            return apra?.AsCycle() ?? Current();
+        }
+
+        public static async Task<AiracCycle> ResolveNextAsync(CancellationToken ct = default)
+        {
+            var apra = await GetApraEditionAsync("dtpp", ApraEdition.Next, ct).ConfigureAwait(false);
+            return apra?.AsCycle() ?? Next();
+        }
+
+        /// <summary>
+        /// Returns true only when the d-tpp Metafile for this cycle is
+        /// actually hosted on aeronav.faa.gov. APRA announces the next
+        /// edition ahead of publication, so checking APRA alone falsely
+        /// greenlights downloads before files exist.
+        /// </summary>
+        public static async Task<bool> IsPublishedAsync(AiracCycle cycle, CancellationToken ct = default)
+        {
+            var url = $"https://aeronav.faa.gov/d-tpp/{cycle.FaaDirectory}/xml_data/d-tpp_Metafile.xml";
+            try
+            {
+                using var req = new HttpRequestMessage(HttpMethod.Head, url);
+                using var resp = await Http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+                return resp.StatusCode == HttpStatusCode.OK;
+            }
+            catch (HttpRequestException ex)
+            {
+                Logger.LogMessage("WARNING", $"d-tpp Metafile probe failed for {cycle.FaaDirectory}: {ex.Message}");
+                return false;
+            }
+            catch (TaskCanceledException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FeBuddyLibrary/Helpers/DownloadHelpers.cs
+++ b/FeBuddyLibrary/Helpers/DownloadHelpers.cs
@@ -1,12 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net;
+using System.Net.Http;
 
 namespace FeBuddyLibrary.Helpers
 {
     public class DownloadHelpers
     {
+        private static void DownloadFile(string url, string destPath)
+        {
+            using var response = SharedHttp.Client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead)
+                                                  .GetAwaiter().GetResult();
+            response.EnsureSuccessStatusCode();
+            using var src = response.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+            using var dst = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            src.CopyTo(dst);
+        }
+
         public static void DownloadAllFiles(string effectiveDate, string airacCycle, bool getMetaFile = true)
         {
             Logger.LogMessage("DEBUG", "DOWNLOADING ALL FILES REQUIRED");
@@ -53,61 +63,30 @@ namespace FeBuddyLibrary.Helpers
                 };
             }
 
-            // Web Client used to connect to the FAA website.
-            using (var client = new WebClient())
+            foreach (string fileName in allURLs.Keys)
             {
-                foreach (string fileName in allURLs.Keys)
+                if (File.Exists($"{GlobalConfig.tempPath}\\{fileName}") && GlobalConfig.DEVMODE)
                 {
-                    if (File.Exists($"{GlobalConfig.tempPath}\\{fileName}") && GlobalConfig.DEVMODE)
-                    {
-                        GlobalConfig.DownloadedFilePaths.Add($"{GlobalConfig.tempPath}\\{fileName}");
-                        continue;
-                    }
-
-                    try
-                    {
-                        Logger.LogMessage("INFO", $"ATTEMPTING TO DOWNLOAD: {fileName}");
-
-                        if (GlobalConfig.hasCurl)
-                        {
-                            if (fileName == $"{effectiveDate}_NWS-WX-STATIONS.xml")
-                            {
-                                BatchFileHelpers.CreateCurlBatchFile("NWS-WX-STATIONS.bat", "https://w1.weather.gov/xml/current_obs/index.xml", fileName);
-                                BatchFileHelpers.ExecuteCurlBatchFile("NWS-WX-STATIONS.bat");
-                            }
-                            else if (fileName == $"{airacCycle}_TELEPHONY.html")
-                            {
-                                BatchFileHelpers.CreateCurlBatchFile("TELEPHONY.bat", "https://www.faa.gov/air_traffic/publications/atpubs/cnt_html/chap3_section_2.html", fileName);
-                                BatchFileHelpers.ExecuteCurlBatchFile("TELEPHONY.bat");
-                            }
-                            else if (fileName == $"{airacCycle}_FAA_Meta.xml")
-                            {
-                                BatchFileHelpers.CreateCurlBatchFile("FAA_Meta.bat", $"https://aeronav.faa.gov/d-tpp/{airacCycle}/xml_data/d-tpp_Metafile.xml", fileName);
-                                BatchFileHelpers.ExecuteCurlBatchFile("FAA_Meta.bat");
-                            }
-                            else
-                            {
-                                client.DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
-                            }
-                        }
-                        else
-                        {
-                            client.DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
-                        }
-                        Logger.LogMessage("INFO", $"DOWNLOAD SUCCESSFUL: {fileName}");
-
-                    }
-                    catch (Exception)
-                    {
-                        Logger.LogMessage("ERROR", $"DOWNLOAD FAILED: {fileName}");
-
-                        MessageBoxHelpers.FileDownloadErrorMB(fileName, allURLs);
-                        Logger.LogMessage("ERROR", $"PROGRAM CLOSING: {fileName}");
-
-                        Environment.Exit(-1);
-                    }
                     GlobalConfig.DownloadedFilePaths.Add($"{GlobalConfig.tempPath}\\{fileName}");
+                    continue;
                 }
+
+                try
+                {
+                    Logger.LogMessage("INFO", $"ATTEMPTING TO DOWNLOAD: {fileName}");
+                    DownloadFile(allURLs[fileName], $"{GlobalConfig.tempPath}\\{fileName}");
+                    Logger.LogMessage("INFO", $"DOWNLOAD SUCCESSFUL: {fileName}");
+                }
+                catch (Exception)
+                {
+                    Logger.LogMessage("ERROR", $"DOWNLOAD FAILED: {fileName}");
+
+                    MessageBoxHelpers.FileDownloadErrorMB(fileName, allURLs);
+                    Logger.LogMessage("ERROR", $"PROGRAM CLOSING: {fileName}");
+
+                    Environment.Exit(-1);
+                }
+                GlobalConfig.DownloadedFilePaths.Add($"{GlobalConfig.tempPath}\\{fileName}");
             }
         }
     }

--- a/FeBuddyLibrary/Helpers/SharedHttp.cs
+++ b/FeBuddyLibrary/Helpers/SharedHttp.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net.Http;
+
+namespace FeBuddyLibrary.Helpers
+{
+    /// <summary>
+    /// Single process-wide HttpClient. Reusing one client avoids socket
+    /// exhaustion from the classic "new HttpClient() per call" anti-pattern
+    /// and picks up the OS TLS 1.2/1.3 defaults on .NET 6.
+    /// </summary>
+    public static class SharedHttp
+    {
+        public static readonly HttpClient Client = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(2),
+        };
+    }
+}

--- a/FeBuddyLibrary/Helpers/WebHelpers.cs
+++ b/FeBuddyLibrary/Helpers/WebHelpers.cs
@@ -1,13 +1,10 @@
-﻿using System.IO;
+using System.IO;
 using System.IO.Compression;
-using System.Net;
-using FeBuddyLibrary.Models.MetaFileModels;
 
 namespace FeBuddyLibrary.Helpers
 {
     public class WebHelpers
     {
-
         public static void DecompressGZipFile(string gzipFilePath, string destFilePath)
         {
             using (FileStream originalFileStream = new FileStream(gzipFilePath, FileMode.Open, FileAccess.Read))
@@ -20,87 +17,6 @@ namespace FeBuddyLibrary.Helpers
                     }
                 }
             }
-        }
-
-        public static bool GetMetaUrlResponse()
-        {
-            Logger.LogMessage("DEBUG", "CHECKING IF NEXT AIRAC HAS THE META FILE OR NOT");
-
-            string nextUrl = $"https://aeronav.faa.gov/d-tpp/{AiracDateCycleModel.AllCycleDates[GlobalConfig.nextAiracDate]}/xml_data/d-tpp_Metafile.xml";
-            //string testUrl = $"https://aeronav.faa.gov/d-tpp/2201/xml_data/d-tpp_Metafile.xml";
-
-            HttpStatusCode result;
-
-            try
-            {
-                var request = HttpWebRequest.Create(nextUrl);
-                request.Method = "HEAD";
-                if (request.GetResponse() is HttpWebResponse response)
-                {
-                    if (response != null)
-                    {
-                        result = response.StatusCode;
-                    }
-
-                    response.Close();
-                }
-
-                Logger.LogMessage("DEBUG", "NEXT AIRAC IS AVAILABLE");
-                return true;
-            }
-            catch (WebException)
-            {
-                Logger.LogMessage("DEBUG", "NEXT AIRAC NOT AVAILABLE");
-
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Get the Airac Effective Dates and Set our Global Variables to it.
-        /// </summary>
-        public static void GetAiracDateFromFAA()
-        {
-            Logger.LogMessage("DEBUG", "SEARCHING FAA WEBSITE FOR AIRAC DATES");
-
-            // FAA URL that contains the effective dates for both Current and Next AIRAC Cycles.
-            string url = "https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/";
-
-            string response;
-
-            BatchFileHelpers.CreateCurlBatchFile("getAiraccEff.bat", "https://www.faa.gov/air_traffic/flight_info/aeronav/aero_data/NASR_Subscription/", $"{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML");
-
-            BatchFileHelpers.ExecuteCurlBatchFile("getAiraccEff.bat");
-
-            if (File.Exists($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML") && File.ReadAllText($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML").Length > 10)
-            {
-                Logger.LogMessage("DEBUG", "GOT RESPONSE FROM FAA WEBSITE");
-                response = File.ReadAllText($"{GlobalConfig.tempPath}\\{GlobalConfig.FaaHtmlFileVariable}_FAA_NASR.HTML");
-
-                Logger.LogMessage("DEBUG", "USER HAS CURL");
-                GlobalConfig.hasCurl = true;
-            }
-            else
-            {
-                Logger.LogMessage("WARNING", "USER DOES NOT HAVE CURL OR IT FAILED");
-                GlobalConfig.hasCurl = false;
-                using (var client = new System.Net.WebClient())
-                {
-                    client.Proxy = null;
-
-                    //client.Proxy = GlobalProxySelection.GetEmptyWebProxy();
-                    response = client.DownloadString(url);
-                    Logger.LogMessage("DEBUG", "GOT AIRAC DATE USING WEBCLIENT");
-                }
-            }
-
-            response.Trim();
-
-            // Find the two strings that contain the effective date and set our Global Variables.
-            GlobalConfig.nextAiracDate = response.Substring(response.IndexOf("./../NASR_Subscription") + 23, 10);
-            GlobalConfig.currentAiracDate = response.Substring(response.LastIndexOf("./../NASR_Subscription") + 23, 10);
-            Logger.LogMessage("INFO", $"CURRENT AIRAC DATE: {GlobalConfig.currentAiracDate} / NEXT AIRAC DATE: {GlobalConfig.nextAiracDate}");
-
         }
     }
 }

--- a/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
+++ b/FeBuddyWinFormUI/WinForms/AiracDataForm.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Drawing.Text;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 using FeBuddyLibrary;
 using FeBuddyLibrary.DataAccess;
@@ -464,11 +465,18 @@ namespace FeBuddyWinFormUI
         {
             Logger.LogMessage("DEBUG", "GETTING AIRAC DATE");
 
+            var publishedTask = AiracHelper.IsPublishedAsync(AiracHelper.Next());
+
             if (GlobalConfig.nextAiracDate == null)
             {
-                WebHelpers.GetAiracDateFromFAA();
+                var currentTask = AiracHelper.ResolveCurrentAsync();
+                var nextTask    = AiracHelper.ResolveNextAsync();
+                Task.WhenAll(currentTask, nextTask, publishedTask).GetAwaiter().GetResult();
+                GlobalConfig.currentAiracDate = currentTask.Result.Effective.ToString("yyyy-MM-dd");
+                GlobalConfig.nextAiracDate    = nextTask.Result.Effective.ToString("yyyy-MM-dd");
+                Logger.LogMessage("INFO", $"CURRENT AIRAC DATE: {GlobalConfig.currentAiracDate} / NEXT AIRAC DATE: {GlobalConfig.nextAiracDate}");
             }
-            nextAiracAvailable = WebHelpers.GetMetaUrlResponse();
+            nextAiracAvailable = publishedTask.GetAwaiter().GetResult();
         }
 
         private void Worker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/FeBuddyWinFormUI/WinForms/UpdateForm.cs
+++ b/FeBuddyWinFormUI/WinForms/UpdateForm.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.IO;
-using System.Net;
 using System.Windows.Forms;
 using FeBuddyLibrary.Helpers;
 
@@ -87,16 +85,9 @@ namespace FeBuddyWinFormUI
         private string ReadChangeLog()
         {
             string output = "";
-            string content = "";
 
             string url = "https://raw.githubusercontent.com/Nikolai558/FE-BUDDY/releases/ChangeLog.md";
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-
-            using (var reader = new StreamReader(response.GetResponseStream()))
-            {
-                content = reader.ReadToEnd();
-            }
+            string content = SharedHttp.Client.GetStringAsync(url).GetAwaiter().GetResult();
 
             foreach (string line in content.Split('\n'))
             {


### PR DESCRIPTION
First — thank you for maintaining FE-BUDDY. The tool is genuinely useful and the existing code made this refactor straightforward to reason about. I've tried to keep the surface area as small as possible and preserve every caller-visible behavior I could.

## Summary

Three related things in one pass:

1. Centralizes HTTP onto a single `HttpClient` (replacing per-call `WebClient`, `HttpWebRequest`, and `new HttpClient()` usage).
2. Replaces the FAA-website HTML-scraping AIRAC lookup with the FAA's own APRA API, with a deterministic offline fallback.
3. Fixes a latent bug in the "is the next AIRAC available?" check that causes it to return `true` before the relevant files are actually published.

## Why each change

### 1. `HttpClient` consolidation

`WebClient` and `HttpWebRequest` are listed as legacy in the .NET docs and Microsoft explicitly recommends `HttpClient` for new code on .NET 6+. That alone wouldn't justify a refactor, but two concrete problems pushed me to do it now:

- **Per-call `HttpClient` is a known socket-exhaustion footgun.** Each instance reserves its underlying socket for the full TIME_WAIT window (roughly 240 seconds on Windows). Under sustained traffic, sockets pile up faster than the OS releases them. The standard fix is a single static client. `SharedHttp.cs` does exactly that, with a 2-minute timeout. Note: `DataAccess/AircraftData.cs` also had a `new HttpClient()` per call — that's migrated as part of this PR so the singleton is consistent across the codebase.
- **Mixing `WebClient`, `HttpWebRequest`, and shell-curl** means three different timeout semantics, three different proxy-handling code paths, and three different exception types to catch. Consolidating onto one client removes that ambiguity.

### 2. APRA replaces the HTML scrape

`WebHelpers.GetAiracDateFromFAA()` currently:

1. Generates a `.bat` file that invokes `curl`,
2. Runs the batch file via cmd,
3. If curl fails, falls back to `WebClient.DownloadString`,
4. Locates the AIRAC dates by `String.IndexOf("./../NASR_Subscription") + 23` and `Substring(... , 10)` against the raw HTML.

I want to be respectful here because clearly this code worked when it was written and has been carrying real users. But the substring-offset extraction is structurally fragile — it breaks the moment the FAA adjusts the markup, the link order, or any whitespace around the anchor. The `.bat` + curl path additionally assumes curl is on `PATH` and that shelling out from cmd is acceptable in the host environment, which isn't always true (locked-down corporate machines, antivirus heuristics on generated batch files, etc.).

The FAA publishes APRA exactly for this purpose:

```
https://external-api.faa.gov/apra/{product}/info?edition=current|next
```

It returns a small XML document with a stable schema, an explicit status code, and authoritative edition metadata. `AiracHelper.GetApraEditionAsync` parses it and returns `null` on any non-200 status or transport failure so callers can fall back cleanly.

For the fallback, `AiracHelper` adds deterministic cycle math: AIRAC cycles are fixed 28-day intervals from the ICAO epoch (cycle 2001 = 2020-01-02), so `Current()` / `Next()` produce the right answer with no network at all. That means the app keeps working if APRA is down — which the old code path could not guarantee, since both its primary (curl) and secondary (`WebClient`) paths required the FAA website to respond.

### 3. The `GetMetaUrlResponse()` bug

This is the technical point I want to be unambiguous about: `WebHelpers.GetMetaUrlResponse()` always returns `true` on the success branch. The local `result = response.StatusCode` is assigned and never read; the method returns `true` for any response that doesn't throw a `WebException`. That includes 3xx redirects and any 2xx response, regardless of whether the file actually exists.

In practice this matters because APRA announces the next edition *before* the d-tpp Metafile is hosted on `aeronav.faa.gov`. During that window, the old code reports "next AIRAC available" and any download attempt against `…/d-tpp/{nextId}/xml_data/d-tpp_Metafile.xml` will 404.

`AiracHelper.IsPublishedAsync` replaces the check with a real `HEAD` request against the actual Metafile URL, returning `true` only on a literal `200 OK`. This is a behavior change, but I'd argue it's the behavior the original method *intended* — it just wasn't reading the status code it captured.

## Files changed

**Added**

- `FeBuddyLibrary/Helpers/SharedHttp.cs` — single static `HttpClient`.
- `FeBuddyLibrary/Helpers/AiracHelper.cs` — cycle math, APRA client, Metafile HEAD probe.

**Modified**

- `FeBuddyLibrary/Helpers/DownloadHelpers.cs` — `WebClient.DownloadFile` → `HttpClient.GetAsync` with `HttpCompletionOption.ResponseHeadersRead` for streaming. Behavior is identical from the caller's perspective.
- `FeBuddyLibrary/Helpers/WebHelpers.cs` — removed `GetMetaUrlResponse()` and `GetAiracDateFromFAA()`. `DecompressGZipFile` is unchanged.
- `FeBuddyLibrary/DataAccess/AircraftData.cs` — per-call `new HttpClient()` → `SharedHttp.Client` (consistency with the rest of the migration).
- `FeBuddyWinFormUI/WinForms/UpdateForm.cs` — `HttpWebRequest` + `StreamReader` → `SharedHttp.Client.GetStringAsync`.
- `FeBuddyWinFormUI/WinForms/AiracDataForm.cs` — `Worker_DoWork` now calls `AiracHelper.ResolveCurrentAsync` / `ResolveNextAsync` / `IsPublishedAsync(Next())`. The three independent network calls run concurrently via `Task.WhenAll` (cuts cold-start AIRAC lookup from ~450 ms sequential to ~250 ms parallel in measured testing). Output strings remain `yyyy-MM-dd` so `GlobalConfig.currentAiracDate` / `nextAiracDate` consumers see no format change.
- `FeBuddyLibrary/GlobalConfig.cs` — removed unused `hasCurl` field. The only writer was `WebHelpers.GetAiracDateFromFAA` (removed here), and the only reader was a now-unreachable branch in `DownloadHelpers.DownloadAllFiles` (also removed). `BatchFileHelpers.cs` itself is left in place in case other paths want it later.

## Compatibility notes

- The FAA `Metafile.xml` HEAD probe is a behavior change. If anything in the UI implicitly assumed "next AIRAC available" was sticky once set, that assumption now resolves the intended way.
- `getAiraccEff.bat` is no longer generated by the AIRAC-date code path. `BatchFileHelpers` itself is untouched and any other batch flows still work.
- `AiracDateCycleModel.AllCycleDates` is still used by several other consumers (`DataAccess/GetFaaMetaFileData.cs`, `DataAccess/PublicationParser.cs`, several `AiracDataForm` call sites). I deliberately did not remove or replace it — that would be a separate, larger refactor. The new `AiracHelper.AiracCycle.Id` produces the same values, so a future PR could consolidate them, but that's out of scope here.

## Testing performed

I built against the existing project files on .NET 6 and ran a battery of automated checks against live FAA endpoints on 2026-05-02. Each check below produced the expected result:

- **APRA schema match.** `https://external-api.faa.gov/apra/dtpp/info?edition=current|next` returns the documented XML. `editionDate` parses cleanly via `ParseExact("MM/dd/yyyy", InvariantCulture)`; namespace `http://arpa.ait.faa.gov/arpa_response` (note: the FAA's actual literal is `arpa`, not a typo of `apra`) matches the constant in `AiracHelper.ApraNs`.
- **APRA agreement with deterministic math.** `ResolveCurrentAsync` returned cycle 2604 effective 2026-04-16 from APRA, matching `AiracHelper.Current()`. `ResolveNextAsync` returned 2605 effective 2026-05-14, matching `AiracHelper.Next()`.
- **Math fallback.** `AiracHelper.Current()` and `Next()` agree with the canonical entries in `AiracDateCycleModel.AllCycleDates` (verified against epoch 2020-01-02 → 2001, 2021-02-25 → 2102, 2022-01-27 → 2201, etc.).
- **Cycle math invariants.** `Cycle.Next.Previous` round-trips to the same cycle. `FaaDirectory == Id`.
- **HEAD probe correctness.** `IsPublishedAsync` returns `true` for the real Metafile URLs (current cycle 2604 → 200) and `false` for a fabricated cycle id (9900 → 404).
- **Parallelism actually runs in parallel.** Sequential cold-start: ~450 ms for the three calls. Parallel via `Task.WhenAll`: ~250 ms. The slowest of the three calls dominates, which is the network floor.
- **End-to-end download.** `SharedHttp.Client.GetStringAsync` against the d-tpp Metafile (10.5 MB) completes successfully and returns valid XML.
- **Singleton verified.** `SharedHttp.Client` returns a referentially-equal instance on every access; configured timeout is the expected 2 minutes.
- **Changelog fetch.** `UpdateForm.ReadChangeLog`'s URL resolves and contains the expected `## Version` markers.
- **Bad-product handling.** `GetApraEditionAsync` against an unknown product name returns `null` rather than throwing — confirms the catch-and-fallback contract.

I cannot reproduce the original `GetMetaUrlResponse()` false-positive scenario right now because APRA and `aeronav.faa.gov` are aligned for cycle 2605 today. The defect remains exactly as described above — the Metafile probe is the correct fix even though it can't be demonstrated on demand in the current cycle window.

## On the bundling

I considered splitting this into separate PRs (HTTP modernization, APRA swap, Metafile-probe fix) but they all touch the same small set of helpers and removing one without the others would create dead code or inconsistent abstractions. If you'd rather review them separately I'm happy to break it apart — just let me know which ordering you'd prefer.

Thanks again for taking the time to look at this.
