### PR TITLE
ChartCode=STR option added in MetaRecordModel

### DIFF
--- a/FeBuddyLibrary/Models/MetaFileModels/MetaRecordModel.cs
+++ b/FeBuddyLibrary/Models/MetaFileModels/MetaRecordModel.cs
@@ -334,7 +334,7 @@ namespace FeBuddyLibrary.Models.MetaFileModels
             {
                 AliasCommand += "/HS";
             }
-            else if (ChartCode == "STAR")
+            else if (ChartCode == "STAR" || ChartCode == "STR")
             {
                 if (!string.IsNullOrEmpty(Faanfd18))
                 {


### PR DESCRIPTION
This option was added in v2.8.0 in GetFaaMetaData but MetaRecordModel was missed.